### PR TITLE
update setup parent class

### DIFF
--- a/Model/Resource/Setup.php
+++ b/Model/Resource/Setup.php
@@ -9,7 +9,7 @@
 
 namespace Ebizmarts\MageMonkey\Model\Resource;
 
-class Setup  extends \Magento\Framework\Module\DataSetup
+class Setup  extends \Magento\Setup\Module\DataSetup
 {
     /**
      * @param \Magento\Framework\Module\Setup\Context $context


### PR DESCRIPTION
\Magento\Framework\Module\DataSetup looks like it has been moved in the magento 2 repo, this commit fixes. It was causing errors during setup:di:compile. PHP Fatal error:  Class 'Magento\Framework\Module\DataSetup' not found in /var/www/src/app/code/Ebizmarts/MageMonkey/Model/Resource/Setup.php on line 13

https://github.com/magento/magento2/commit/997631fddf288bd2bbdf6a2cf0ccbb8e1e0b2995
