### PR TITLE
This should fix the Logger error once and for all

### DIFF
--- a/Model/Logger/Handler.php
+++ b/Model/Logger/Handler.php
@@ -11,7 +11,7 @@
 
 namespace Ebizmarts\MageMonkey\Model\Logger;
 
-use Monolog;
+use Monolog\Logger as EbizmartsLogger;
 
 class Handler extends \Magento\Framework\Logger\Handler\Base
 {
@@ -25,5 +25,5 @@ class Handler extends \Magento\Framework\Logger\Handler\Base
      * Logging level
      * @var int
      */
-    protected $loggerType = Logger::INFO;
+    protected $loggerType = EbizmartsLogger::INFO;
 }


### PR DESCRIPTION
Solution for PHP ERROR: PHP Fatal error:  Cannot use Monolog\Logger as Logger because the name is already in use

(Tested on Magento 2.0.7 EE)
